### PR TITLE
Fix ordinary function compositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,20 @@ illustrated in [samples/demo.py](samples/demo.py):
 ```python
 import composer
 
+def authenticate(args):
+    return {'value': args['password'] == 'abc123'}
+
+def success(args):
+    return {'message': 'success'}
+
+def failure(args):
+    return {'message': 'failure'}
+
 def main():
     return composer.when(
-        composer.action('authenticate',  { 'action': lambda args: { 'value': args['password'] == 'abc123' } }),
-        composer.action('success', { 'action': lambda args: { 'message': 'success' } }),
-        composer.action('failure', { 'action': lambda args: { 'message': 'failure' } }))
+        composer.action('authenticate',  { 'action': authenticate }),
+        composer.action('success', { 'action': success }),
+        composer.action('failure', { 'action': failure }))
 ```
 Compositions compose actions using [combinator](docs/COMBINATORS.md) methods. These methods
 implement the typical control-flow constructs of a sequential imperative

--- a/samples/demo.py
+++ b/samples/demo.py
@@ -16,8 +16,17 @@
 """
 import composer
 
+def authenticate(args):
+    return {'value': args['password'] == 'abc123'}
+
+def success(args):
+    return {'message': 'success'}
+
+def failure(args):
+    return {'message': 'failure'}
+
 def main():
     return composer.when(
-        composer.action('authenticate',  { 'action': lambda args: { 'value': args['password'] == 'abc123' } }),
-        composer.action('success', { 'action': lambda args: { 'message': 'success' } }),
-        composer.action('failure', { 'action': lambda args: { 'message': 'failure' } }))
+        composer.action('authenticate',  { 'action': authenticate }),
+        composer.action('success', { 'action': success }),
+        composer.action('failure', { 'action': failure }))

--- a/src/composer/composer.py
+++ b/src/composer/composer.py
@@ -463,6 +463,7 @@ def main(args):
         else:
             try:
                 exc = inspect.getsource(options['action'])
+                entry_point = options['action'].__name__
             except OSError:
                 raise ComposerError('Invalid argument "options" in "action" combinator', options['action'])
     elif 'action' in options and (isinstance(options['action'], str) or isinstance(options['action'],  dict)):
@@ -470,6 +471,8 @@ def main(args):
 
     if isinstance(exc, str):
         exc = { 'kind': 'python:3', 'code': exc }
+        if entry_point:
+            exc['main'] = entry_point
 
     composition = { 'type': 'action', 'name': name, '.combinator': lambda: combinators['action']}
     if exc is not None:

--- a/src/pycompose/__main__.py
+++ b/src/pycompose/__main__.py
@@ -20,6 +20,7 @@
 import argparse
 import json
 import composer
+import imp
 
 def main():
     parser = argparse.ArgumentParser(description='compile compositions', prog='pycompose', usage='%(prog)s composition.py command [flags]')
@@ -30,16 +31,11 @@ def main():
     args = parser.parse_args()
 
     filename = args.file
-    with open(filename, encoding='UTF-8') as f:
-        source = f.read()
 
     main = '''exec(code + "\\n__out__['value'] = main()", {'__out__':__out__})'''
 
     try:
-        out = {'value': None}
-        exec(main, {'code': source, '__out__': out})
-
-        composition = out['value']
+        composition = imp.load_source('compose.imported', filename).main()
         composition = composition.compile()
 
         if args.ast:


### PR DESCRIPTION
This PR allows for compositions of ordinary Python functions as in

```python
import composer

def action1(args):
  return {'value': 'success'}

def main():
  return composer.action('action1', {'action': action1})
```

Previoulsly, this would fail due to the `inspect.getsource(fun)` failing when the composition code is executed from a string. The composition code is now imported using the `imp` package and its main function is being called regularly, allowing the composer code to get its source code and generate the composition.