### PR TITLE
Add IAM token expiration check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   global:
     - IGNORE_CERTS=true
     - IC_FN_CONFIG_FILE=./tests/cf-plugin-config.json
+    - IC_CONFIG_FILE=./tests/cf-config.json
   matrix:
     - TOXENV=check
 

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -30,8 +30,10 @@ from conductor import __version__
 from .ibmcloud_utils import (
     NamespaceType,
     get_iam_token,
+    get_iam_token_timestamp,
     get_namespace_id,
-    get_namespace_mode
+    get_namespace_mode,
+    iam_token_expired
 )
 
 def escape(str):
@@ -118,6 +120,15 @@ def openwhisk(options):
     if namespace_mode == NamespaceType.IAM:
         options['auth_header'] = get_iam_token()
         options['namespace'] = get_namespace_id()
+        token_timestamp = get_iam_token_timestamp()
+
+        if iam_token_expired(token_timestamp):
+            print(
+                'Error: Your IAM token seems to be expired. Plase perform an `ibmcloud login` '
+                'to make sure your token is up to date.'
+            )
+            raise Exception('IAM token expired')
+
     else:
         options['api_key'] = api_key
         options['namespace'] = '_'

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -29,7 +29,7 @@ import traceback
 from conductor import __version__
 from .ibmcloud_utils import (
     NamespaceType,
-    get_iam_auth_header,
+    get_iam_token,
     get_namespace_id,
     get_namespace_mode
 )
@@ -116,7 +116,7 @@ def openwhisk(options):
 
     namespace_mode = get_namespace_mode()
     if namespace_mode == NamespaceType.IAM:
-        options['auth_header'] = get_iam_auth_header()
+        options['auth_header'] = get_iam_token()
         options['namespace'] = get_namespace_id()
     else:
         options['api_key'] = api_key

--- a/src/conductor/conductor.py
+++ b/src/conductor/conductor.py
@@ -123,11 +123,10 @@ def openwhisk(options):
         token_timestamp = get_iam_token_timestamp()
 
         if iam_token_expired(token_timestamp):
-            print(
+            raise Exception(
                 'Error: Your IAM token seems to be expired. Plase perform an `ibmcloud login` '
                 'to make sure your token is up to date.'
             )
-            raise Exception('IAM token expired')
 
     else:
         options['api_key'] = api_key

--- a/src/conductor/ibmcloud_utils.py
+++ b/src/conductor/ibmcloud_utils.py
@@ -59,7 +59,7 @@ def get_namespace_mode():
     return get_namespace()['mode']
 
 
-def get_iam_auth_header():
+def get_config_ibmcloud():
     ic_config_path = os.environ.get(
         'IC_CONFIG_FILE',
         os.path.expanduser('~/.bluemix/config.json')
@@ -72,4 +72,8 @@ def get_iam_auth_header():
         print('Could not open ibmcloud config')
         raise e
 
-    return ic_config['IAMToken']
+    return ic_config
+
+
+def get_iam_token():
+    return get_config_ibmcloud()['IAMToken']

--- a/src/conductor/ibmcloud_utils.py
+++ b/src/conductor/ibmcloud_utils.py
@@ -25,7 +25,7 @@ class NamespaceType(Enum):
     CF = 2
 
 
-def get_namespace():
+def get_config_functions():
     fn_config_path = os.environ.get(
         'IC_FN_CONFIG_FILE',
         os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json')
@@ -38,25 +38,23 @@ def get_namespace():
         print('Could not open ibmcloud functions plugin config')
         raise e
 
-    namespace_mode_str = fn_config['WskCliNamespaceMode']
+    return fn_config
+
+
+def get_namespace_id():
+    return get_config_functions()['WskCliNamespaceId']
+
+
+def get_namespace_mode():
+    namespace_mode_str = get_config_functions()['WskCliNamespaceMode']
+
     try:
         namespace_mode = NamespaceType[namespace_mode_str]
     except KeyError as e:
         print(f'Error: Found unknown namespace mode {namespace_mode_str} in functions config.')
         raise e
 
-    return {
-        'id': fn_config['WskCliNamespaceId'],
-        'mode': namespace_mode
-    }
-
-
-def get_namespace_id():
-    return get_namespace()['id']
-
-
-def get_namespace_mode():
-    return get_namespace()['mode']
+    return namespace_mode
 
 
 def get_config_ibmcloud():

--- a/src/pydeploy/__main__.py
+++ b/src/pydeploy/__main__.py
@@ -99,8 +99,7 @@ def main():
         names = ' '.join([n['name'] for n in actions])
         print('ok: created action'+ ('s' if len(names) > 1 else '') + '' + names)
     except Exception as err:
-        # FIXME not all exceptions have the error attribute!
-        print(err.error)
+        print(err)
         sys.exit(500 - 256)
 
 if __name__ == '__main__':

--- a/tests/test_ibmcloud_utils.py
+++ b/tests/test_ibmcloud_utils.py
@@ -8,11 +8,21 @@ from conductor.ibmcloud_utils import (
     iam_token_expired
 )
 
+fn_config_path = os.environ.get(
+    'IC_FN_CONFIG_FILE',
+    os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json')
+)
+
+ic_config_path = os.environ.get(
+    'IC_CONFIG_FILE',
+    os.path.expanduser('~/.bluemix/config.json')
+)
+
 
 class TestIamTokenExpireCheck:
     def test_read_timestamp(self, fs):
         fs.create_file(
-            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            fn_config_path,
             contents='{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
         )
         timestamp = get_iam_token_timestamp()
@@ -20,7 +30,7 @@ class TestIamTokenExpireCheck:
 
     def test_read_timestamp_tz_ignored(self, fs):
         fs.create_file(
-            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            fn_config_path,
             contents='{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+06:00" }'
         )
         timestamp = get_iam_token_timestamp()
@@ -40,11 +50,11 @@ class TestIamTokenExpireCheck:
 
     def test_conductor_fails_when_token_expired(self, fs):
         fs.create_file(
-            os.path.expanduser('~/.bluemix/config.json'),
+            ic_config_path,
             contents='{ "IAMToken": "some-token" }')
 
         fs.create_file(
-            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            fn_config_path,
             contents='''
 {
     "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00",

--- a/tests/test_ibmcloud_utils.py
+++ b/tests/test_ibmcloud_utils.py
@@ -67,4 +67,4 @@ class TestIamTokenExpireCheck:
         with pytest.raises(Exception) as e:
             openwhisk({})
 
-        assert 'IAM token expired' in str(e)
+        assert 'IAM token seems to be expired' in str(e)

--- a/tests/test_ibmcloud_utils.py
+++ b/tests/test_ibmcloud_utils.py
@@ -1,0 +1,60 @@
+import os
+import datetime
+import pytest
+
+from conductor.conductor import openwhisk
+from conductor.ibmcloud_utils import (
+    get_iam_token_timestamp,
+    iam_token_expired
+)
+
+
+class TestIamTokenExpireCheck:
+    def test_read_timestamp(self, fs):
+        fs.create_file(
+            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            contents='{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
+        )
+        timestamp = get_iam_token_timestamp()
+        assert timestamp == datetime.datetime(2021, 3, 15, 13, 24, 14)
+
+    def test_read_timestamp_tz_ignored(self, fs):
+        fs.create_file(
+            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            contents='{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+06:00" }'
+        )
+        timestamp = get_iam_token_timestamp()
+        assert timestamp == datetime.datetime(2021, 3, 15, 13, 24, 14)
+
+    def test_not_expired(self):
+        time_refreshed = datetime.datetime(2021, 3, 15, 13, 24, 14)
+        time_reference = datetime.datetime(2021, 3, 15, 13, 30, 0)
+        token_expired = iam_token_expired(time_refreshed, time_reference)
+        assert token_expired == False
+
+    def test_expired(self):
+        time_refreshed = datetime.datetime(2021, 3, 15, 13, 24, 14)
+        time_reference = datetime.datetime(2021, 3, 15, 14, 25, 0)
+        token_expired = iam_token_expired(time_refreshed, time_reference)
+        assert token_expired == True
+
+    def test_conductor_fails_when_token_expired(self, fs):
+        fs.create_file(
+            os.path.expanduser('~/.bluemix/config.json'),
+            contents='{ "IAMToken": "some-token" }')
+
+        fs.create_file(
+            os.path.expanduser('~/.bluemix/plugins/cloud-functions/config.json'),
+            contents='''
+{
+    "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00",
+    "WskCliNamespaceId": "some-namespace-id",
+    "WskCliNamespaceMode": "IAM"
+}
+'''
+        )
+
+        with pytest.raises(Exception) as e:
+            openwhisk({})
+
+        assert 'IAM token expired' in str(e)

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     pytest-travis-fold
     pytest-cov
     requests
+    pyfakefs
 commands =
     {posargs:py.test -s --cov --cov-report=term-missing -vv tests}
 


### PR DESCRIPTION
This will fail deploying when the value of `IamTimeTokenRefreshed` in the functions `config.json` is older than one hour and print instructions for refreshing it by logging in again.

To make the change more lightweight, the helper functions have been changed slightly. The actual implementation of the expiration check has been done in 1ac3f2a.